### PR TITLE
Rename to trivial_constructor.

### DIFF
--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -34,7 +34,7 @@ module Dry
     ALL_PRIMITIVES.each do |name, primitive|
       register(
         "strict.#{name}",
-        Type[primitive].new(Type.method(:constructor), primitive: primitive).constrained(type: primitive)
+        Type[primitive].new(Type.method(:trivial_constructor), primitive: primitive).constrained(type: primitive)
       )
     end
 
@@ -42,7 +42,7 @@ module Dry
     ALL_PRIMITIVES.each do |name, primitive|
       register(
         name.to_s,
-        Type[primitive].new(Type.method(:constructor), primitive: primitive)
+        Type[primitive].new(Type.method(:trivial_constructor), primitive: primitive)
       )
     end
 

--- a/lib/dry/types/type.rb
+++ b/lib/dry/types/type.rb
@@ -24,7 +24,7 @@ module Dry
         end
       end
 
-      def self.constructor(input)
+      def self.trivial_constructor(input)
         input
       end
 


### PR DESCRIPTION
It doesn't clear from name what the method does and it's easily confused with `#constructor` instance method.
Ideally, it should be renamed to _identity_, but as it's used as a constructor it is still a constructor. But trivial.