### PR TITLE
Removing duplication of logic

### DIFF
--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -15,7 +15,7 @@ module Dry
       end
 
       def self.attributes(new_schema)
-        prev_schema = schema || {}
+        prev_schema = schema
 
         @schema = prev_schema.merge(new_schema)
         @constructor = Types['coercible.hash'].strict(schema)


### PR DESCRIPTION
Prior to this commit, the code for Dry::Types::Schema.attributes was
doing the following (distilled into a more concrete example):

```ruby
prev_schema = schema || {}

def schema
  @schema || {}
end
```

When expanded that looked something like the following:

```ruby
prev_schema = (@schema || {}) || {}
```

This change is meant to reduce the above to:

```ruby
prev_schema = @schema || {}
```